### PR TITLE
Update dependencies

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -42,7 +42,7 @@ ESLINT_OPTION =
         'no-shadow': 0
         'no-new': 0
         'no-underscore-dangle': 0
-        'no-multi-spaces': false
+        'no-multi-spaces': 0
         'no-native-reassign': 0
         'no-loop-func': 0
     env:

--- a/package.json
+++ b/package.json
@@ -19,20 +19,20 @@
     "url": "https://github.com/estools/esrecurse.git"
   },
   "dependencies": {
-    "estraverse": "~3.1.0"
+    "estraverse": "~4.1.0"
   },
   "devDependencies": {
-    "chai": "^2.1.1",
+    "chai": "^3.3.0",
     "coffee-script": "^1.9.1",
     "esprima": "^2.1.0",
-    "gulp": "~3.8.10",
-    "gulp-bump": "^0.2.2",
-    "gulp-eslint": "^0.6.0",
-    "gulp-filter": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-bump": "^1.0.0",
+    "gulp-eslint": "^1.0.0",
+    "gulp-filter": "^3.0.1",
     "gulp-git": "^1.1.0",
-    "gulp-mocha": "~2.0.0",
+    "gulp-mocha": "^2.1.3",
     "gulp-tag-version": "^1.2.1",
-    "jsdoc": "~3.3.0-alpha10",
+    "jsdoc": "^3.3.0-alpha10",
     "minimist": "^1.1.0"
   },
   "license": "BSD-2-Clause",


### PR DESCRIPTION
- npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
- I also updated ESLint config according to the warning from the latest ESLint:

```
Error: CLI:
Configuration for rule "no-multi-spaces" is invalid: Value "false" is the wrong type.
```
