### PR TITLE
Use a Standard-Compliant License Identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,7 @@
     "jsdoc": "~3.3.0-alpha10",
     "minimist": "^1.1.0"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/estools/esrecurse/raw/master/LICENSE.BSD"
-    }
-  ],
+  "license": "BSD-2-Clause",
   "scripts": {
     "test": "gulp travis",
     "unit-test": "gulp test",


### PR DESCRIPTION
Specifying the type and URL is [deprecated](https://github.com/npm/npm/issues/4473#issuecomment-103551773).

Actually, npm shows the following error:

```
npm WARN EPACKAGEJSON esrecurse@3.1.1 No license field.
```

https://docs.npmjs.com/files/package.json#license
