### PR TITLE
Use SVG badge instead of PNG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Esrecurse [![Build Status](https://secure.travis-ci.org/estools/esrecurse.png)](http://travis-ci.org/estools/esrecurse)
+### Esrecurse [![Build Status](https://travis-ci.org/estools/esrecurse.svg?branch=master)](http://travis-ci.org/estools/esrecurse)
 
 Esrecurse ([esrecurse](http://github.com/estools/esrecurse)) is
 [ECMAScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm)


### PR DESCRIPTION
SVG badges look beautiful on retina display.

| before | after |
| --- | --- |
| [![Build Status](https://travis-ci.org/estools/esrecurse.png?branch=master)](https://travis-ci.org/estools/esrecurse) | [![Build Status](https://travis-ci.org/estools/esrecurse.svg?branch=master)](https://travis-ci.org/estools/esrecurse) |
