### PR TITLE
Add childVisitorKeys option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,41 @@ DerivedVisitor.prototype.XXXStatement = function (node) {
 };
 ```
 
+The `childVisitorKeys` option does customize the behavoir of `this.visitChildren(node)`.
+We can use user-defined node types.
+
+```javascript
+// This tree contains a user-defined `TestExpression` node.
+var tree = {
+    type: 'TestExpression',
+
+    // This 'argument' is the property containing the other **node**.
+    argument: {
+        type: 'Literal',
+        value: 20
+    },
+
+    // This 'extended' is the property not containing the other **node**.
+    extended: true
+};
+esrecurse.visit(
+    ast,
+    {
+        Literal: function (node) {
+            // do something...
+        }
+    },
+    {
+        // Extending the existing traversing rules.
+        childVisitorKeys: {
+            // TargetNodeName: [ 'keys', 'containing', 'the', 'other', '**node**' ]
+            TestExpression: ['argument']
+        }
+    }
+);
+```
+
+
 ### License
 
 Copyright (C) 2014 [Yusuke Suzuki](https://github.com/Constellation)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ esrecurse.visit(
 );
 ```
 
+We can use the `fallback` option as well.
+If the `fallback` option is `"iteration"`, `esrecurse` would visit all enumerable properties of unknown nodes.
+Please note circular references cause the stack overflow. AST might have circular references in additional properties for some purpose (e.g. `node.parent`).
+
+```javascript
+esrecurse.visit(
+    ast,
+    {
+        Literal: function (node) {
+            // do something...
+        }
+    },
+    {
+        fallback: 'iteration'
+    }
+);
+```
 
 ### License
 

--- a/esrecurse.js
+++ b/esrecurse.js
@@ -62,6 +62,7 @@
         this.__childVisitorKeys = options.childVisitorKeys
             ? assign({}, estraverse.VisitorKeys, options.childVisitorKeys)
             : estraverse.VisitorKeys;
+        this.__fallback = options.fallback === 'iteration';
     }
 
     /* Default method for visiting children.
@@ -79,7 +80,11 @@
 
         children = this.__childVisitorKeys[type];
         if (!children) {
-            children = objectKeys(node);
+            if (this.__fallback) {
+                children = objectKeys(node);
+            } else {
+                throw new Error('Unknown node type ' + type + '.');
+            }
         }
 
         for (i = 0, iz = children.length; i < iz; ++i) {

--- a/esrecurse.js
+++ b/esrecurse.js
@@ -24,10 +24,12 @@
 (function () {
     'use strict';
 
-    var estraverse,
+    var assign,
+        estraverse,
         isArray,
         objectKeys;
 
+    assign = require('object-assign');
     estraverse = require('estraverse');
 
     isArray = Array.isArray || function isArray(array) {
@@ -53,8 +55,13 @@
         return (nodeType === estraverse.Syntax.ObjectExpression || nodeType === estraverse.Syntax.ObjectPattern) && key === 'properties';
     }
 
-    function Visitor(visitor) {
+    function Visitor(visitor, options) {
+        options = options || {};
+
         this.__visitor = visitor ||  this;
+        this.__childVisitorKeys = options.childVisitorKeys
+            ? assign({}, estraverse.VisitorKeys, options.childVisitorKeys)
+            : estraverse.VisitorKeys;
     }
 
     /* Default method for visiting children.
@@ -70,7 +77,7 @@
 
         type = node.type || estraverse.Syntax.Property;
 
-        children = estraverse.VisitorKeys[type];
+        children = this.__childVisitorKeys[type];
         if (!children) {
             children = objectKeys(node);
         }
@@ -111,8 +118,8 @@
 
     exports.version = require('./package.json').version;
     exports.Visitor = Visitor;
-    exports.visit = function (node, visitor) {
-        var v = new Visitor(visitor);
+    exports.visit = function (node, visitor, options) {
+        var v = new Visitor(visitor, options);
         v.visit(node);
     };
 }());

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/estools/esrecurse.git"
   },
   "dependencies": {
-    "estraverse": "~4.1.0"
+    "estraverse": "~4.1.0",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/test/traverse.coffee
+++ b/test/traverse.coffee
@@ -157,3 +157,51 @@ describe 'inherit Visitor', ->
         visitor.visit(tree)
 
         expect(visitor.log).to.deep.equal [ 'decl', 'a', 'rest' ]
+
+describe 'bidirectional relationship at non visitor keys.', ->
+    it 'ExpressionStatement <-> Identifier', ->
+        tree =
+            type: 'ExpressionStatement'
+            expression: {
+                type: 'Identifier'
+                name: 'foo'
+            }
+        tree.expression.parent = tree
+
+        log = []
+        esrecurse.visit tree,
+            Identifier: (node) ->
+                log.push(node.name)
+
+
+        expect(log).to.deep.equal ['foo']
+
+    it 'ExpressionStatement <-> UnknownNode with the childVisitorKeys option', ->
+        tree =
+            type: 'ExpressionStatement'
+            expression: {
+                type: 'UnknownNode'
+                argument: {
+                    type: 'Identifier'
+                    name: 'foo'
+                }
+            }
+        tree.expression.parent = tree
+        tree.expression.argument.parent = tree.expression
+
+        log = []
+        esrecurse.visit(
+            tree,
+            {
+                Identifier: (node) ->
+                    log.push(node.name)
+            },
+            {
+                childVisitorKeys: {
+                    UnknownNode: ['argument']
+                }
+            }
+        )
+
+
+        expect(log).to.deep.equal ['foo']

--- a/test/traverse.coffee
+++ b/test/traverse.coffee
@@ -48,7 +48,44 @@ describe 'object expression', ->
         expect(log).to.deep.equal ['a', 'b']
 
 
-describe 'no listed keys fallback', ->
+describe 'non listed keys throw an error', ->
+    it 'traverse', ->
+        tree =
+            type: 'TestStatement'
+            id: {
+                type: 'Identifier'
+                name: 'decl'
+            }
+            params: [{
+                type: 'Identifier'
+                name: 'a'
+            }]
+            defaults: [{
+                type: 'Literal'
+                value: 20
+            }]
+            rest: {
+                type: 'Identifier'
+                name: 'rest'
+            }
+            body:
+                type: 'BlockStatement'
+                body: []
+
+        expect(->
+            log = []
+            esrecurse.visit(
+                tree,
+                {
+                    Literal: (node) ->
+                        log.push(node.value)
+                }
+            )
+        ).to.throw 'Unknown node type TestStatement.'
+
+
+
+describe 'no listed keys fallback if "fallback" option was given', ->
     it 'traverse', ->
         tree =
             type: 'TestStatement'
@@ -73,9 +110,16 @@ describe 'no listed keys fallback', ->
                 body: []
 
         log = []
-        esrecurse.visit tree,
-            Literal: (node) ->
-                log.push(node.value)
+        esrecurse.visit(
+            tree,
+            {
+                Literal: (node) ->
+                    log.push(node.value)
+            },
+            {
+                fallback: 'iteration'
+            }
+        )
 
         expect(log).to.deep.equal [ 20 ]
 
@@ -107,7 +151,7 @@ describe 'inherit Visitor', ->
         class Derived extends esrecurse.Visitor
             constructor: ->
                 @log = []
-                super @
+                super @, {fallback: 'iteration'}
 
             Identifier: (node) ->
                 @log.push node.name
@@ -146,7 +190,7 @@ describe 'inherit Visitor', ->
         class Derived extends esrecurse.Visitor
             constructor: ->
                 @log = []
-                super @
+                super @, {fallback: 'iteration'}
 
             BlockStatement: (node) ->
 


### PR DESCRIPTION
This PR adds a new option: `childVisitorKeys`.

This option gives us an ability to extend the behavior of the `Visitor#visitChildren(node)` method.
This option is useful for modules which have several internal visitors such as `escope`.

An use case in my head:

``` js
const escope = require("escope");
const jsxKeys = require("estraverse-fb/keys");

const result = escope.analyze(ast, {childVisitorKeys: jsxKeys});
```

Related: https://github.com/eslint/eslint/issues/5007

I'm happy to follow review and direction.
