### PR TITLE
Update estraverse from v4.1.x to v4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/estools/esrecurse.git"
   },
   "dependencies": {
-    "estraverse": "~4.1.0",
+    "estraverse": "^4.1.0",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
