### PR TITLE
Remove support for Node.js versions < 4

### DIFF
--- a/esrecurse.js
+++ b/esrecurse.js
@@ -24,25 +24,7 @@
 (function () {
     'use strict';
 
-    var assign,
-        estraverse,
-        isArray,
-        objectKeys;
-
-    assign = require('object-assign');
-    estraverse = require('estraverse');
-
-    isArray = Array.isArray || function isArray(array) {
-        return Object.prototype.toString.call(array) === '[object Array]';
-    };
-
-    objectKeys = Object.keys || function (o) {
-        var keys = [], key;
-        for (key in o) {
-            keys.push(key);
-        }
-        return keys;
-    };
+    var estraverse = require('estraverse');
 
     function isNode(node) {
         if (node == null) {
@@ -60,10 +42,10 @@
 
         this.__visitor = visitor ||  this;
         this.__childVisitorKeys = options.childVisitorKeys
-            ? assign({}, estraverse.VisitorKeys, options.childVisitorKeys)
+            ? Object.assign({}, estraverse.VisitorKeys, options.childVisitorKeys)
             : estraverse.VisitorKeys;
         if (options.fallback === 'iteration') {
-            this.__fallback = objectKeys;
+            this.__fallback = Object.keys;
         } else if (typeof options.fallback === 'function') {
             this.__fallback = options.fallback;
         }
@@ -94,7 +76,7 @@
         for (i = 0, iz = children.length; i < iz; ++i) {
             child = node[children[i]];
             if (child) {
-                if (isArray(child)) {
+                if (Array.isArray(child)) {
                     for (j = 0, jz = child.length; j < jz; ++j) {
                         if (child[j]) {
                             if (isNode(child[j]) || isProperty(type, children[i])) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "esrecurse.js",
   "version": "4.2.0",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0"
   },
   "maintainers": [
     {
@@ -19,8 +19,7 @@
     "url": "https://github.com/estools/esrecurse.git"
   },
   "dependencies": {
-    "estraverse": "^4.1.0",
-    "object-assign": "^4.0.1"
+    "estraverse": "^4.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Travis test were not running for Node 0.10 and 0.12 and they've been out of active support for almost a year. It's time to drop support for them.