### PR TITLE
add package-lock.json to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ t.js
 /cover_html/
 /coverage/
 /.coverage_data/
+package-lock.json


### PR DESCRIPTION
I see package-lock.json in my node_modules.

By adding to .npmignore we can save atleast 150 KB to everyone's harddrive.